### PR TITLE
add makePri in the platform creation step

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -75,6 +75,12 @@ function Platform (packageName, platforms) {
       
         return fileTools.copyFile(source, target);        
       })
+      //run makePRI so it works on xbox et all
+      .then(function(){
+      return appPackage.makePri(manifestDir, manifestDir).catch(function (err) {
+        self.warn('Failed to compile the application resources (makePri). ' + err.message);
+      })
+      })
       // Save the w3c manifest for .web package generation
       .then(function () {
         self.info('Saving the original W3C manifest to the app folder...');


### PR DESCRIPTION
Mariano,
  This is what I want to do.  Call the MakePri when we generate the project.  I am not with my mac to test it out, but I believe this will work on the mac as well.  It's just something we will do for everyone.  When another process calls makePri it will just overwrite this one, which is fine.  Can you test this and then we want to do a quick update for windows platform (we can just push out everything that have tested as v0.7).
